### PR TITLE
ocr: make vLLM the supported runtime backend (transformers backend is broken on dev)

### DIFF
--- a/docs/operations/deepseek_runtime_contract.md
+++ b/docs/operations/deepseek_runtime_contract.md
@@ -1,0 +1,82 @@
+# DeepSeek runtime contract
+
+Status: vLLM is the supported runtime backend. The transformers backend is
+preserved as best-effort and is currently broken with the upstream
+DeepSeek-OCR-2 bundled modeling code (see "Known issues" below).
+
+## Supported runtime
+
+`runtime_backend = "vllm"` is the default and only supported value.
+
+The DeepSeek-OCR-2 model is served via the script
+`src/glossapi/ocr/deepseek/run_pdf_ocr_vllm.py`, which loads the model with
+vLLM's own model loader and exposes the model through vLLM's batched
+inference API. The runner subprocesses this script per lane and reads back
+markdown plus per-page metrics from disk.
+
+## Page-level efficiency contract
+
+The vLLM runtime ships with a blank-page skip guard:
+
+- `_is_effectively_empty_page(image_stats, repair_mode)` runs on the
+  pre-rendered image stats (overall and per-region dark ratios). When
+  `repair_mode == "auto"` (default) and the page falls below the configured
+  brightness thresholds, the runtime emits a synthetic page metric
+  (`repair_strategy="skip_empty"`, `empty_page_skipped=True`, `infer_sec=0.0`)
+  and counts it in the aggregate `empty_pages_skipped`. No model forward pass
+  happens for skipped pages.
+
+This guard does NOT exist on the transformers script. It is one of the
+reasons the supported backend is vLLM.
+
+## Backend choice — why vLLM
+
+- vLLM ships the blank-page skip guard described above.
+- vLLM uses its own model loader and does not exercise the transformers
+  dynamic-module path that breaks on DeepSeek-OCR-2 with current upstream
+  transformers.
+- vLLM enables batched inference across multi-GPU lanes via the `exact_fill`
+  scheduler in `src/glossapi/ocr/deepseek/scheduling.py`.
+
+Reference benchmark on 2× A100 SXM4 40GB (`a2-highgpu-2g`, us-west1-b):
+- 10 OpenArchives PDFs, 683 pages, scheduler `exact_fill`, target 160 pages
+  per batch.
+- vLLM wall time: 276.16 s (4 min 36 s); 0.65–0.76 s/page per GPU.
+- Auto-repair flagged 86 pages and successfully repaired 85 of them.
+
+## Replacing or extending the backend
+
+The runner is a subprocess-per-script architecture. To add a new backend:
+
+1. Add a new `run_pdf_ocr_<backend>.py` script in
+   `src/glossapi/ocr/deepseek/`.
+2. Wire its CLI surface into `runner.py`'s
+   `_build_cli_command` (and `defaults.py` if the backend introduces
+   defaults).
+3. Add a runtime choice in `defaults.DEFAULT_RUNTIME_BACKEND` and the
+   acceptance check at `runner.py:run_for_files`.
+4. Document the contract here.
+
+The `scheduling.py` page router and `work_queue.py` durable batch queue are
+backend-agnostic and consume the same `WorkSlice` / `(doc_id, page_number)`
+abstractions regardless of which inference backend runs.
+
+## Known issues
+
+- **transformers backend is broken** with the version pulled transitively
+  by `vllm==0.18.0`. The DeepSeek-OCR-2 bundled `modeling_deepseekv2.py`
+  imports `LlamaFlashAttention2` from `transformers.models.llama.modeling_llama`,
+  which was removed upstream in transformers ≥ 4.46. The transformers script
+  also requires `matplotlib` at first import, which is not declared in the
+  `deepseek` extra. We do not fix these here; the supported backend is vLLM.
+
+## Testing
+
+- `tests/test_deepseek_runner_contract.py` — runner contract tests.
+- `tests/test_ocr_dispatch_backends.py` — dispatch tests.
+- `tests/test_deepseek_scheduling.py` — scheduling tests.
+- `dependency_setup/deepseek_gpu_smoke.py` — minimal real-GPU smoke test.
+- `src/glossapi/scripts/deepseek_pipeline_benchmark.py` — full pipeline
+  benchmark with per-GPU and per-lane metrics; supports
+  `--scheduler {whole_doc, fixed_shard, exact_fill}` and
+  `--runtime-backend {vllm, transformers}`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,12 @@ cuda = [
     "torchvision==0.20.1",
 ]
 # DeepSeek OCR backend extras (Torch should be installed from the PyTorch index).
+# vLLM is the supported runtime backend. transformers is pulled transitively by
+# vllm; we no longer pin it here because the DeepSeek-OCR-2 bundled modeling
+# code requires the pre-4.46 attention API and the only working path is via
+# vllm's own model loader.
 deepseek = [
     "vllm==0.18.0",
-    "transformers==4.57.6",
-    "tokenizers==0.22.2",
     "accelerate>=1.2.1,<2",
     "pymupdf==1.24.10",
     "Pillow==12.1.1",

--- a/src/glossapi/ocr/deepseek/defaults.py
+++ b/src/glossapi/ocr/deepseek/defaults.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-DEFAULT_RUNTIME_BACKEND = "transformers"
+DEFAULT_RUNTIME_BACKEND = "vllm"
 DEFAULT_OCR_PROFILE = "markdown_grounded"
 DEFAULT_ATTN_BACKEND = "auto"
 DEFAULT_RENDER_DPI = 144

--- a/src/glossapi/ocr/deepseek/runner.py
+++ b/src/glossapi/ocr/deepseek/runner.py
@@ -1531,16 +1531,26 @@ def run_for_files(
         metrics_path = metrics_dir / f"{stem}.metrics.json"
         if not md_path.exists():
             raise FileNotFoundError(f"DeepSeek OCR did not produce markdown for {name}: {md_path}")
-        if not md_path.read_text(encoding="utf-8").strip():
-            raise RuntimeError(f"DeepSeek OCR produced empty markdown for {name}: {md_path}")
+        text_payload = md_path.read_text(encoding="utf-8")
         page_count = _page_count(pdf_path)
+        result_payload: Optional[Dict[str, Any]] = None
         if metrics_path.exists():
             try:
-                results[stem] = json.loads(metrics_path.read_text(encoding="utf-8"))
-                continue
+                result_payload = json.loads(metrics_path.read_text(encoding="utf-8"))
             except Exception:
-                pass
-        results[stem] = {"page_count": page_count}
-        metrics_path.write_text(json.dumps(results[stem], indent=2), encoding="utf-8")
+                result_payload = None
+        if result_payload is None:
+            result_payload = {"page_count": page_count}
+        else:
+            result_payload.setdefault("page_count", page_count)
+        if not text_payload.strip():
+            result_payload["empty_markdown"] = True
+            metrics_path.write_text(json.dumps(result_payload, indent=2), encoding="utf-8")
+            LOGGER.warning("DeepSeek OCR produced empty markdown for %s: %s", name, md_path)
+            results[stem] = result_payload
+            continue
+        results[stem] = result_payload
+        if not metrics_path.exists():
+            metrics_path.write_text(json.dumps(result_payload, indent=2), encoding="utf-8")
 
     return results

--- a/tests/test_deepseek_runner_contract.py
+++ b/tests/test_deepseek_runner_contract.py
@@ -615,6 +615,46 @@ def test_runner_selects_vllm_script_when_requested(tmp_path, monkeypatch):
     assert result["doc"]["page_count"] == 1
 
 
+def test_runner_resolves_standard_vllm_defaults_when_omitted(tmp_path, monkeypatch):
+    from glossapi.ocr.deepseek import runner
+    from glossapi.ocr.deepseek.defaults import DEFAULT_GPU_MEMORY_UTILIZATION, DEFAULT_RENDER_DPI
+
+    corpus = _mk_corpus(tmp_path)
+    (corpus.input_dir / "doc.pdf").write_bytes(b"%PDF-1.4\n%real\n")
+
+    calls = {}
+
+    def fake_run_cli(input_dir, output_dir, **kwargs):
+        calls["input_dir"] = input_dir
+        calls["kwargs"] = dict(kwargs)
+        md_dir = output_dir / "markdown"
+        metrics_dir = output_dir / "json" / "metrics"
+        md_dir.mkdir(parents=True, exist_ok=True)
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        (md_dir / "doc.md").write_text("ok\n", encoding="utf-8")
+        (metrics_dir / "doc.metrics.json").write_text('{"page_count": 1}', encoding="utf-8")
+
+    monkeypatch.setattr(runner, "_run_cli", fake_run_cli)
+    monkeypatch.setenv("GLOSSAPI_DEEPSEEK_MODEL_DIR", str(tmp_path))
+    monkeypatch.setenv(
+        "GLOSSAPI_DEEPSEEK_RUNNER_SCRIPT",
+        str(Path(runner.__file__).resolve().parent / "run_pdf_ocr_vllm.py"),
+    )
+    monkeypatch.setenv("GLOSSAPI_DEEPSEEK_PYTHON", sys.executable)
+
+    runner.run_for_files(
+        corpus,
+        ["doc.pdf"],
+        runtime_backend="vllm",
+        render_dpi=None,
+        gpu_memory_utilization=None,
+    )
+
+    assert calls["input_dir"] == corpus.input_dir.resolve()
+    assert calls["kwargs"]["render_dpi"] == DEFAULT_RENDER_DPI
+    assert calls["kwargs"]["gpu_memory_utilization"] == DEFAULT_GPU_MEMORY_UTILIZATION
+
+
 def test_runner_prefers_repo_local_deepseek_runtime_when_env_missing(tmp_path, monkeypatch):
     from glossapi.ocr.deepseek import runner, runtime_paths
 


### PR DESCRIPTION
## Summary

The transformers backend on current dev is broken, not slow. DeepSeek-OCR-2's bundled `modeling_deepseekv2.py` requires `LlamaFlashAttention2` from `transformers.models.llama.modeling_llama`, which was removed upstream in `transformers >= 4.46`. `vllm==0.18.0` (pinned in the `deepseek` extra) transitively pulls `transformers==4.57.6`, so anyone following the documented setup with the current default hits an `ImportError` in ~7 seconds before any OCR happens. vLLM is the only working backend.

This PR:

- **Flips `DEFAULT_RUNTIME_BACKEND` from `"transformers"` to `"vllm"`** (`src/glossapi/ocr/deepseek/defaults.py`).
- **Drops the redundant `transformers==4.57.6` and `tokenizers==0.22.2` pins** from the `deepseek` extra in `pyproject.toml` (both come transitively via vllm at the version vllm requires; the explicit pins were redundant and misleading because they made the conflict harder to see).
- **Adds `docs/operations/deepseek_runtime_contract.md`** documenting the supported backend, the page-level blank-page skip guard (vLLM-only), and how to add a new backend.
- **Replaces the `RuntimeError` on empty markdown** with a per-document `empty_markdown=True` metric + warning log so one bad PDF no longer aborts the entire batch (`src/glossapi/ocr/deepseek/runner.py`). Forward-port of `6ce0d9c` from `codex/ocr-env-fix`, rebased onto dev's current runner layout.
- **Adds `test_runner_resolves_standard_vllm_defaults_when_omitted`** to pin the contract that calling `run_for_files` with `runtime_backend="vllm"` and explicit `None` for `render_dpi` / `gpu_memory_utilization` resolves to `DEFAULT_RENDER_DPI` / `DEFAULT_GPU_MEMORY_UTILIZATION`. Forward-port from `codex/ocr-vllm-defaults-refactor`.

Net diff: 5 files, +144 / -10.

## Benchmark

Verified on a 2× A100 SXM4 40GB (`a2-highgpu-2g`, us-west1-b, image `pytorch-2-9-cu129-ubuntu-2404-nvidia-580`) using `src/glossapi/scripts/deepseek_pipeline_benchmark.py` with `--scheduler exact_fill --target-batch-pages 160 --workers-per-gpu 1`:

| backend | wall_time | pages | pages/sec |
|---|---|---|---|
| **vLLM** | **276.16 s** (4 min 36 s) | 683 | **2.47** |
| transformers | 7.21 s (failed at model load — see Critical finding above) | 0 | n/a |

Per-GPU: GPU0 363 pages / 276 s (0.76 s/page); GPU1 320 pages / 208 s (0.65 s/page). Auto-repair fired on 86 pages, repaired 85. No failures.

Input set: 10 OpenArchives PDFs sampled at size percentiles {1, 10, 25, 40, 50, 60, 75, 90, 95, 99} from the canonical raw corpus.

## Test plan

- [x] `python3 -m ast` parses all touched Python files
- [x] `tomllib` parses pyproject.toml; deepseek extras correctly filtered
- [x] vLLM end-to-end on 10 real OpenArchives PDFs across 2 A100s, 0 failures
- [x] vLLM markdown spot-checked on 2 docs (clean Greek, headings, page-split markers preserved)
- [ ] Reviewer should check whether dropping the `transformers==4.57.6` pin from the extra is acceptable for downstream consumers (it's redundant — vllm pulls the same version transitively — but explicit removal is a behaviour change to the manifest)
- [ ] Reviewer should consider whether `run_pdf_ocr_transformers.py` and the `runtime_backend == "transformers"` code paths should be removed in a follow-up (they are dead until upstream DeepSeek-OCR-2 ships compatible bundled modeling code)

## Deferred to follow-up PRs

- Cleaner-side `ocr_render.py` + `text_surface_metrics.py` extraction from `faa1362` — 6/11 functions to extract have different bodies on dev vs faa1362 (dev's Apr 14 OCR-speedup wave modified them); needs a careful function-by-function merge with review.
- Padding `docs/architecture/ocr_cleaning_runtime.md` with the Code Layout / Stage Boundary / Field Ownership sections describing those modules, once they exist.