### PR TITLE
cleaner Stage B: extract ocr_render.py + text_surface_metrics.py from phase_clean.py

### DIFF
--- a/docs/architecture/ocr_cleaning_runtime.md
+++ b/docs/architecture/ocr_cleaning_runtime.md
@@ -20,6 +20,74 @@ debug logic to evolve faster than the real cleaner. Sharing one analyzer avoids
 that drift: if the debug page is right, the clean page is operating on the same
 decisions.
 
+The same alignment rule applies to metadata. When `clean_ocr()` writes cleaned
+markdown, it now scores parquet-facing OCR metrics from that cleaned directory.
+Without that, downstream `export` can read cleaned text while still carrying
+raw-OCR `char_count_no_comments`, `is_empty`, or repeat diagnostics in parquet.
+
+## Code Layout
+
+The OCR cleaner is split by responsibility so detector policy does not drift
+into rendering or table-specific cleanup:
+
+- `src/glossapi/corpus/phase_clean.py`
+  - owns analyzer order, worker orchestration, and clean/debug mode selection
+- `src/glossapi/corpus/ocr_table.py`
+  - owns HTML-table classification, dropping policy, and HTML->Markdown conversion
+- `src/glossapi/corpus/ocr_render.py`
+  - owns span merging, clean/debug rendering, and `match_index.jsonl` row generation
+- `src/glossapi/corpus/text_surface_metrics.py`
+  - owns shared published-surface metric helpers such as `char_count_no_comments`
+    and `is_empty`
+
+This split is deliberate. The project needs one place to decide *what* a match
+is, and a separate place to decide *how* that decision becomes visible output.
+That boundary is one of the main protections against random debug/clean drift.
+
+## Stage Boundary: `clean_ocr()` vs `clean()`
+
+These two stages deliberately remain separate:
+
+- `clean_ocr()`
+  - sits on the `corpus.ocr` path
+  - owns OCR artifact removal and OCR-specific metrics
+- `clean()`
+  - sits primarily on the `corpus.extract` path
+  - owns broader clean/export quality metrics
+
+The OCR rerun path reuses `clean()` afterward because `export` still expects the
+generic clean/export fields. That reuse is intentional orchestration, not an
+argument that the two stages should collapse into one function.
+
+## Field Ownership
+
+The practical parquet contract is:
+
+- OCR-owned fields
+  - `percentage_greek`
+  - `latin_percentage`
+  - `polytonic_ratio`
+  - `char_count_no_comments`
+  - `is_empty`
+  - `ocr_noise_suspect`
+  - `ocr_noise_flags`
+  - `ocr_repeat_phrase_run_max`
+  - `ocr_repeat_line_run_max`
+  - `ocr_repeat_suspicious_line_count`
+  - `ocr_repeat_suspicious_line_ratio`
+- clean/export-owned fields
+  - `greek_badness_score`
+  - `mojibake_badness_score`
+  - `needs_ocr`
+  - `filter`
+  - other generic quality-routing fields
+
+This ownership split is the reason the post-OCR sequence is explicit:
+
+1. `clean_ocr()` updates the OCR-owned layer on the OCR-cleaned text surface.
+2. `clean(..., write_cleaned_files=False)` refreshes the generic clean/export
+   layer on that same surface.
+
 ## Why The Cleaner Is Not One Generic Matcher
 
 The cleaner is trying to remove OCR- or VLM-induced garbage, not every repeated

--- a/src/glossapi/corpus/ocr_render.py
+++ b/src/glossapi/corpus/ocr_render.py
@@ -1,0 +1,374 @@
+"""Shared OCR span rendering and match-index helpers.
+
+This module owns the last stage of OCR page handling:
+- merge raw detector spans into one reviewed span plan
+- render that exact plan in `debug` or `clean` mode
+- serialize match metadata for later inspection
+
+Keeping this logic out of `phase_clean.py` is intentional. The analyzer should
+answer *what* spans exist and in what ownership order; this module controls
+*how* those exact spans become page text and debug sidecars.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .ocr_table import (
+    render_table_html_for_clean as _render_table_html_for_clean,
+    render_table_html_for_output as _render_table_html_for_output,
+    replace_html_tables_with_markdown as _replace_html_tables_with_markdown,
+)
+
+# Neighboring same-category spans may merge when the visible separator is still
+# short enough to read as one corrupted region rather than two separate
+# failures. This is intentionally more permissive than the older 10-char rule.
+WORD_REPEAT_MERGE_MAX_NONWHITESPACE_GAP = 40
+
+
+def _gap_has_at_most_n_nonwhitespace_chars(text: str, start: int, end: int, limit: int) -> bool:
+    if start >= end:
+        return True
+    count = 0
+    for ch in text[start:end]:
+        if not ch.isspace():
+            count += 1
+            if count > limit:
+                return False
+    return True
+
+
+def _clean_fill_for_removed_span(page_text: str, start: int, end: int) -> str:
+    removed = page_text[start:end]
+    prev_char = page_text[start - 1] if start > 0 else ""
+    next_char = page_text[end] if end < len(page_text) else ""
+    if "\n" in removed:
+        if prev_char == "\n" or next_char == "\n":
+            return ""
+        return "\n"
+    if prev_char and next_char and not prev_char.isspace() and not next_char.isspace():
+        return " "
+    return ""
+
+
+def _merge_labeled_raw_spans(text: str, spans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not spans:
+        return []
+
+    text_len = len(text)
+    sanitized_spans: List[Dict[str, Any]] = []
+    for span in spans:
+        start = max(0, int(span["start"]))
+        end = min(text_len, int(span["end"]))
+        if start >= text_len or end <= start:
+            continue
+        sanitized = dict(span)
+        sanitized["start"] = start
+        sanitized["end"] = end
+        sanitized_spans.append(sanitized)
+    if not sanitized_spans:
+        return []
+
+    spans = sorted(sanitized_spans, key=lambda item: (item["start"], item["end"]))
+    merged: List[Dict[str, Any]] = []
+    for span in spans:
+        if not merged:
+            merged.append(dict(span))
+            continue
+
+        previous = merged[-1]
+        overlaps = span["start"] <= previous["end"]
+        close_gap = (
+            not overlaps
+            and previous["category"] == span["category"]
+            and previous["category"] != "table"
+            and _gap_has_at_most_n_nonwhitespace_chars(
+                text,
+                previous["end"],
+                span["start"],
+                WORD_REPEAT_MERGE_MAX_NONWHITESPACE_GAP,
+            )
+        )
+        if overlaps or close_gap:
+            same_single_type = previous.get("match_types", []) == span.get("match_types", [])
+            same_kind = previous.get("kind") == span.get("kind")
+            previous["start"] = min(previous["start"], span["start"])
+            previous["end"] = max(previous["end"], span["end"])
+            previous["match_types"] = sorted(
+                set(previous.get("match_types", [])) | set(span.get("match_types", []))
+            )
+            if (
+                previous.get("kind") is None
+                and span.get("kind") is not None
+                and previous.get("match_types", []) == span.get("match_types", [])
+            ):
+                previous["kind"] = span.get("kind")
+            if "period" in span:
+                previous["period"] = min(previous.get("period", span["period"]), span["period"])
+            if "repetitions" in span:
+                previous["repetitions"] = max(
+                    previous.get("repetitions", span["repetitions"]),
+                    span["repetitions"],
+                )
+            if "tail_chars" in span:
+                previous["tail_chars"] = max(
+                    previous.get("tail_chars", 0),
+                    span.get("tail_chars", 0),
+                )
+            if (
+                same_single_type
+                and same_kind
+                and previous.get("item_count") is not None
+                and span.get("item_count") is not None
+            ):
+                previous["item_count"] = int(previous["item_count"]) + int(span["item_count"])
+            continue
+        merged.append(dict(span))
+    return merged
+
+
+def _summarize_merged_labeled_spans(
+    merged_spans: List[Dict[str, Any]],
+) -> Tuple[List[str], int, int, int, int, int]:
+    seen_types: Set[str] = set()
+    numeric_count = 0
+    word_count = 0
+    latex_count = 0
+    table_count = 0
+    hybrid_count = 0
+    for span in merged_spans:
+        seen_types.update(span.get("match_types", []))
+        if span["category"] == "numeric":
+            numeric_count += 1
+        elif span["category"] == "word":
+            word_count += 1
+        elif span["category"] == "latex":
+            latex_count += 1
+        elif span["category"] == "table":
+            table_count += 1
+        elif span["category"] == "hybrid":
+            hybrid_count += 1
+    return (
+        sorted(seen_types),
+        numeric_count,
+        word_count,
+        latex_count,
+        table_count,
+        hybrid_count,
+    )
+
+
+def _render_page_from_merged_labeled_spans(
+    page_text: str,
+    merged_spans: List[Dict[str, Any]],
+    *,
+    mode: str,
+) -> str:
+    if not merged_spans:
+        return _replace_html_tables_with_markdown(page_text)
+
+    parts: List[str] = []
+    pos = 0
+    for span in merged_spans:
+        start = span["start"]
+        end = span["end"]
+        if start > pos:
+            parts.append(_replace_html_tables_with_markdown(page_text[pos:start]))
+        match_types = list(span.get("match_types", []))
+        if mode == "debug":
+            open_tag = f'<match of type {",".join(match_types)}'
+            if match_types == ["word_repeat"]:
+                open_tag += f' period={span.get("period", 0)} reps={span.get("repetitions", 0)}'
+            elif match_types == ["latex_repeat"]:
+                if span.get("kind"):
+                    open_tag += f' kind={span.get("kind")}'
+                if span.get("item_count") is not None:
+                    open_tag += f' items={span.get("item_count")}'
+            elif match_types == ["table_repeat"]:
+                if span.get("kind"):
+                    open_tag += f' kind={span.get("kind")}'
+                if span.get("row_count") is not None:
+                    open_tag += f' rows={span.get("row_count")}'
+                if span.get("duplicate_rows") is not None:
+                    open_tag += f' dup_rows={span.get("duplicate_rows")}'
+                if span.get("nonempty_ratio") is not None:
+                    open_tag += f' nonempty_ratio={span.get("nonempty_ratio")}'
+                if span.get("word_count") is not None:
+                    open_tag += f' words={span.get("word_count")}'
+                if span.get("char_count") is not None:
+                    open_tag += f' chars={span.get("char_count")}'
+            elif match_types == ["hybrid_repeat"]:
+                if span.get("kind"):
+                    open_tag += f' kind={span.get("kind")}'
+                if span.get("item_count") is not None:
+                    open_tag += f' items={span.get("item_count")}'
+                if span.get("cycle_len") is not None:
+                    open_tag += f' cycle={span.get("cycle_len")}'
+            open_tag += ">"
+            parts.append(open_tag)
+            if match_types == ["table_repeat"]:
+                parts.append(
+                    _render_table_html_for_output(
+                        page_text[start:end],
+                        match_kind=span.get("kind"),
+                    )
+                )
+            else:
+                parts.append(page_text[start:end])
+            parts.append("</match>")
+        else:
+            if match_types == ["table_repeat"]:
+                parts.append(
+                    _render_table_html_for_clean(
+                        page_text[start:end],
+                        match_kind=span.get("kind"),
+                    )
+                )
+            else:
+                parts.append(_clean_fill_for_removed_span(page_text, start, end))
+        pos = end
+    if pos < len(page_text):
+        parts.append(_replace_html_tables_with_markdown(page_text[pos:]))
+    return "".join(parts)
+
+
+def _render_page_with_labeled_spans_result(
+    page_text: str,
+    spans: List[Dict[str, Any]],
+    *,
+    mode: str = "debug",
+) -> Dict[str, Any]:
+    if mode not in {"debug", "clean"}:
+        raise ValueError(f"Unsupported OCR render mode: {mode}")
+    merged_spans = _merge_labeled_raw_spans(page_text, spans)
+    (
+        page_types,
+        numeric_count,
+        word_count,
+        latex_count,
+        table_count,
+        hybrid_count,
+    ) = _summarize_merged_labeled_spans(merged_spans)
+    rendered_page = _render_page_from_merged_labeled_spans(
+        page_text,
+        merged_spans,
+        mode=mode,
+    )
+    return {
+        "rendered_page": rendered_page,
+        "merged_spans": merged_spans,
+        "page_types": page_types,
+        "page_numeric_count": numeric_count,
+        "page_word_count": word_count,
+        "page_latex_count": latex_count,
+        "page_table_count": table_count,
+        "page_hybrid_count": hybrid_count,
+    }
+
+
+def _render_page_with_labeled_spans(
+    page_text: str,
+    spans: List[Dict[str, Any]],
+    *,
+    mode: str = "debug",
+) -> Tuple[str, List[str], int, int, int, int, int]:
+    """Render one page from a shared span plan.
+
+    `debug` and `clean` intentionally share the exact same merged span plan.
+    The only difference is how that plan is rendered:
+    - debug wraps the matched source surface in `<match ...>` tags
+    - clean removes or rewrites the matched surface according to policy
+
+    Keeping both modes on one renderer prevents the real cleaner from drifting
+    away from the reviewed debug output.
+    """
+    result = _render_page_with_labeled_spans_result(page_text, spans, mode=mode)
+    return (
+        str(result["rendered_page"]),
+        list(result["page_types"]),
+        int(result["page_numeric_count"]),
+        int(result["page_word_count"]),
+        int(result["page_latex_count"]),
+        int(result["page_table_count"]),
+        int(result["page_hybrid_count"]),
+    )
+
+
+def _annotate_page_with_labeled_spans(
+    page_text: str,
+    spans: List[Dict[str, Any]],
+) -> Tuple[str, List[str], int, int, int, int, int]:
+    return _render_page_with_labeled_spans(page_text, spans, mode="debug")
+
+
+def _utf8_prefix_byte_offsets(text: str) -> List[int]:
+    offsets = [0]
+    total = 0
+    for char in text:
+        total += len(char.encode("utf-8"))
+        offsets.append(total)
+    return offsets
+
+
+def _span_repeat_count(span: Dict[str, Any]) -> Optional[int]:
+    if span.get("repetitions") is not None:
+        return int(span["repetitions"])
+    if span.get("item_count") is not None:
+        return int(span["item_count"])
+    if span.get("duplicate_rows") is not None:
+        return int(span["duplicate_rows"])
+    return None
+
+
+def _build_match_index_rows(
+    page_text: str,
+    merged_spans: List[Dict[str, Any]],
+    *,
+    source_path: Path,
+    page_number: int,
+    debug_output_path: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    if not merged_spans:
+        return []
+    byte_offsets = _utf8_prefix_byte_offsets(page_text)
+    rows: List[Dict[str, Any]] = []
+    for match_index, span in enumerate(merged_spans, start=1):
+        start = int(span["start"])
+        end = int(span["end"])
+        match_text = page_text[start:end]
+        rows.append(
+            {
+                "match_id": f"{source_path.stem}:page:{page_number}:match:{match_index}",
+                "source_path": str(source_path),
+                "source_stem": source_path.stem,
+                "debug_output_path": None if debug_output_path is None else str(debug_output_path),
+                "page_number": int(page_number),
+                "page_index_in_file": int(page_number),
+                "match_index_in_page": int(match_index),
+                "start_char": start,
+                "end_char": end,
+                "start_byte": int(byte_offsets[start]),
+                "end_byte": int(byte_offsets[end]),
+                "match_length_chars": int(end - start),
+                "match_length_bytes": int(byte_offsets[end] - byte_offsets[start]),
+                "match_types": list(span.get("match_types", [])),
+                "match_type": ",".join(span.get("match_types", [])),
+                "category": str(span.get("category", "")),
+                "kind": span.get("kind"),
+                "repeat_count": _span_repeat_count(span),
+                "period": span.get("period"),
+                "repetitions": span.get("repetitions"),
+                "tail_chars": span.get("tail_chars"),
+                "item_count": span.get("item_count"),
+                "cycle_len": span.get("cycle_len"),
+                "row_count": span.get("row_count"),
+                "duplicate_rows": span.get("duplicate_rows"),
+                "nonempty_ratio": span.get("nonempty_ratio"),
+                "word_count": span.get("word_count"),
+                "char_count": span.get("char_count"),
+                "matched_text": match_text,
+            }
+        )
+    return rows
+
+

--- a/src/glossapi/corpus/phase_clean.py
+++ b/src/glossapi/corpus/phase_clean.py
@@ -49,6 +49,20 @@ from .ocr_table import (
 from .corpus_skiplist import _SkiplistManager, _resolve_skiplist_path
 from .corpus_state import _ProcessingStateManager
 from .corpus_utils import _maybe_import_torch
+from .ocr_render import (
+    _gap_has_at_most_n_nonwhitespace_chars,
+    _clean_fill_for_removed_span,
+    _merge_labeled_raw_spans,
+    _summarize_merged_labeled_spans,
+    _render_page_from_merged_labeled_spans,
+    _render_page_with_labeled_spans_result,
+    _render_page_with_labeled_spans,
+    _annotate_page_with_labeled_spans,
+    _utf8_prefix_byte_offsets,
+    _span_repeat_count,
+    _build_match_index_rows,
+)
+from .text_surface_metrics import sanitized_char_count
 
 PAGE_SPLIT_MARKER = "<--- Page Split --->"
 WORD_REPEAT_HASH_MASK = (1 << 64) - 1
@@ -344,19 +358,6 @@ def _extract_latex_segments(text: str) -> List[Dict[str, Any]]:
         segments.append({"start": start, "end": end, "kind": kind, "text": body})
         last_end = end
     return segments
-
-
-def _clean_fill_for_removed_span(page_text: str, start: int, end: int) -> str:
-    removed = page_text[start:end]
-    prev_char = page_text[start - 1] if start > 0 else ""
-    next_char = page_text[end] if end < len(page_text) else ""
-    if "\n" in removed:
-        if prev_char == "\n" or next_char == "\n":
-            return ""
-        return "\n"
-    if prev_char and next_char and not prev_char.isspace() and not next_char.isspace():
-        return " "
-    return ""
 
 
 def _find_table_repeat_spans(page_text: str) -> List[Dict[str, Any]]:
@@ -1435,18 +1436,6 @@ def _gap_has_fewer_than_n_nonwhitespace_chars(text: str, start: int, end: int, l
     return True
 
 
-def _gap_has_at_most_n_nonwhitespace_chars(text: str, start: int, end: int, limit: int) -> bool:
-    if start >= end:
-        return True
-    count = 0
-    for ch in text[start:end]:
-        if not ch.isspace():
-            count += 1
-            if count > limit:
-                return False
-    return True
-
-
 def _latex_segments_are_local(page_text: str, left: Dict[str, Any], right: Dict[str, Any]) -> bool:
     return _gap_has_fewer_than_n_nonwhitespace_chars(
         page_text,
@@ -1951,330 +1940,9 @@ def _shared_repeat_match_type(segment: str) -> Optional[str]:
     return None
 
 
-def _merge_labeled_raw_spans(text: str, spans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    if not spans:
-        return []
-
-    text_len = len(text)
-    sanitized_spans: List[Dict[str, Any]] = []
-    for span in spans:
-        start = max(0, int(span["start"]))
-        end = min(text_len, int(span["end"]))
-        if start >= text_len or end <= start:
-            continue
-        sanitized = dict(span)
-        sanitized["start"] = start
-        sanitized["end"] = end
-        sanitized_spans.append(sanitized)
-    if not sanitized_spans:
-        return []
-
-    spans = sorted(sanitized_spans, key=lambda item: (item["start"], item["end"]))
-    merged: List[Dict[str, Any]] = []
-    for span in spans:
-        if not merged:
-            merged.append(dict(span))
-            continue
-
-        previous = merged[-1]
-        overlaps = span["start"] <= previous["end"]
-        close_gap = (
-            not overlaps
-            and previous["category"] == span["category"]
-            and previous["category"] != "table"
-            and _gap_has_at_most_n_nonwhitespace_chars(
-                text,
-                previous["end"],
-                span["start"],
-                WORD_REPEAT_MERGE_MAX_NONWHITESPACE_GAP,
-            )
-        )
-        if overlaps or close_gap:
-            same_single_type = previous.get("match_types", []) == span.get("match_types", [])
-            same_kind = previous.get("kind") == span.get("kind")
-            previous["start"] = min(previous["start"], span["start"])
-            previous["end"] = max(previous["end"], span["end"])
-            previous["match_types"] = sorted(
-                set(previous.get("match_types", [])) | set(span.get("match_types", []))
-            )
-            if (
-                previous.get("kind") is None
-                and span.get("kind") is not None
-                and previous.get("match_types", []) == span.get("match_types", [])
-            ):
-                previous["kind"] = span.get("kind")
-            if "period" in span:
-                previous["period"] = min(previous.get("period", span["period"]), span["period"])
-            if "repetitions" in span:
-                previous["repetitions"] = max(
-                    previous.get("repetitions", span["repetitions"]),
-                    span["repetitions"],
-                )
-            if "tail_chars" in span:
-                previous["tail_chars"] = max(
-                    previous.get("tail_chars", 0),
-                    span.get("tail_chars", 0),
-                )
-            if (
-                same_single_type
-                and same_kind
-                and previous.get("item_count") is not None
-                and span.get("item_count") is not None
-            ):
-                previous["item_count"] = int(previous["item_count"]) + int(span["item_count"])
-            continue
-        merged.append(dict(span))
-    return merged
-
-
-def _summarize_merged_labeled_spans(
-    merged_spans: List[Dict[str, Any]],
-) -> Tuple[List[str], int, int, int, int, int]:
-    seen_types: Set[str] = set()
-    numeric_count = 0
-    word_count = 0
-    latex_count = 0
-    table_count = 0
-    hybrid_count = 0
-    for span in merged_spans:
-        seen_types.update(span.get("match_types", []))
-        if span["category"] == "numeric":
-            numeric_count += 1
-        elif span["category"] == "word":
-            word_count += 1
-        elif span["category"] == "latex":
-            latex_count += 1
-        elif span["category"] == "table":
-            table_count += 1
-        elif span["category"] == "hybrid":
-            hybrid_count += 1
-    return (
-        sorted(seen_types),
-        numeric_count,
-        word_count,
-        latex_count,
-        table_count,
-        hybrid_count,
-    )
-
-
-def _render_page_from_merged_labeled_spans(
-    page_text: str,
-    merged_spans: List[Dict[str, Any]],
-    *,
-    mode: str,
-) -> str:
-    if not merged_spans:
-        return _replace_html_tables_with_markdown(page_text)
-
-    parts: List[str] = []
-    pos = 0
-    for span in merged_spans:
-        start = span["start"]
-        end = span["end"]
-        if start > pos:
-            parts.append(_replace_html_tables_with_markdown(page_text[pos:start]))
-        match_types = list(span.get("match_types", []))
-        if mode == "debug":
-            open_tag = f'<match of type {",".join(match_types)}'
-            if match_types == ["word_repeat"]:
-                open_tag += f' period={span.get("period", 0)} reps={span.get("repetitions", 0)}'
-            elif match_types == ["latex_repeat"]:
-                if span.get("kind"):
-                    open_tag += f' kind={span.get("kind")}'
-                if span.get("item_count") is not None:
-                    open_tag += f' items={span.get("item_count")}'
-            elif match_types == ["table_repeat"]:
-                if span.get("kind"):
-                    open_tag += f' kind={span.get("kind")}'
-                if span.get("row_count") is not None:
-                    open_tag += f' rows={span.get("row_count")}'
-                if span.get("duplicate_rows") is not None:
-                    open_tag += f' dup_rows={span.get("duplicate_rows")}'
-                if span.get("nonempty_ratio") is not None:
-                    open_tag += f' nonempty_ratio={span.get("nonempty_ratio")}'
-                if span.get("word_count") is not None:
-                    open_tag += f' words={span.get("word_count")}'
-                if span.get("char_count") is not None:
-                    open_tag += f' chars={span.get("char_count")}'
-            elif match_types == ["hybrid_repeat"]:
-                if span.get("kind"):
-                    open_tag += f' kind={span.get("kind")}'
-                if span.get("item_count") is not None:
-                    open_tag += f' items={span.get("item_count")}'
-                if span.get("cycle_len") is not None:
-                    open_tag += f' cycle={span.get("cycle_len")}'
-            open_tag += ">"
-            parts.append(open_tag)
-            if match_types == ["table_repeat"]:
-                parts.append(
-                    _render_table_html_for_output(
-                        page_text[start:end],
-                        match_kind=span.get("kind"),
-                    )
-                )
-            else:
-                parts.append(page_text[start:end])
-            parts.append("</match>")
-        else:
-            if match_types == ["table_repeat"]:
-                parts.append(
-                    _render_table_html_for_clean(
-                        page_text[start:end],
-                        match_kind=span.get("kind"),
-                    )
-                )
-            else:
-                parts.append(_clean_fill_for_removed_span(page_text, start, end))
-        pos = end
-    if pos < len(page_text):
-        parts.append(_replace_html_tables_with_markdown(page_text[pos:]))
-    return "".join(parts)
-
-
-def _render_page_with_labeled_spans_result(
-    page_text: str,
-    spans: List[Dict[str, Any]],
-    *,
-    mode: str = "debug",
-) -> Dict[str, Any]:
-    if mode not in {"debug", "clean"}:
-        raise ValueError(f"Unsupported OCR render mode: {mode}")
-    merged_spans = _merge_labeled_raw_spans(page_text, spans)
-    (
-        page_types,
-        numeric_count,
-        word_count,
-        latex_count,
-        table_count,
-        hybrid_count,
-    ) = _summarize_merged_labeled_spans(merged_spans)
-    rendered_page = _render_page_from_merged_labeled_spans(
-        page_text,
-        merged_spans,
-        mode=mode,
-    )
-    return {
-        "rendered_page": rendered_page,
-        "merged_spans": merged_spans,
-        "page_types": page_types,
-        "page_numeric_count": numeric_count,
-        "page_word_count": word_count,
-        "page_latex_count": latex_count,
-        "page_table_count": table_count,
-        "page_hybrid_count": hybrid_count,
-    }
-
-
-def _render_page_with_labeled_spans(
-    page_text: str,
-    spans: List[Dict[str, Any]],
-    *,
-    mode: str = "debug",
-) -> Tuple[str, List[str], int, int, int, int, int]:
-    """Render one page from a shared span plan.
-
-    `debug` and `clean` intentionally share the exact same merged span plan.
-    The only difference is how that plan is rendered:
-    - debug wraps the matched source surface in `<match ...>` tags
-    - clean removes or rewrites the matched surface according to policy
-
-    Keeping both modes on one renderer prevents the real cleaner from drifting
-    away from the reviewed debug output.
-    """
-    result = _render_page_with_labeled_spans_result(page_text, spans, mode=mode)
-    return (
-        str(result["rendered_page"]),
-        list(result["page_types"]),
-        int(result["page_numeric_count"]),
-        int(result["page_word_count"]),
-        int(result["page_latex_count"]),
-        int(result["page_table_count"]),
-        int(result["page_hybrid_count"]),
-    )
-
-
-def _annotate_page_with_labeled_spans(
-    page_text: str,
-    spans: List[Dict[str, Any]],
-) -> Tuple[str, List[str], int, int, int, int, int]:
-    return _render_page_with_labeled_spans(page_text, spans, mode="debug")
-
-
 def _count_hybrid_matches_in_page(page_text: str, spans: List[Dict[str, Any]]) -> int:
     merged_spans = _merge_labeled_raw_spans(page_text, spans)
     return sum(1 for span in merged_spans if span.get("category") == "hybrid")
-
-
-def _utf8_prefix_byte_offsets(text: str) -> List[int]:
-    offsets = [0]
-    total = 0
-    for char in text:
-        total += len(char.encode("utf-8"))
-        offsets.append(total)
-    return offsets
-
-
-def _span_repeat_count(span: Dict[str, Any]) -> Optional[int]:
-    if span.get("repetitions") is not None:
-        return int(span["repetitions"])
-    if span.get("item_count") is not None:
-        return int(span["item_count"])
-    if span.get("duplicate_rows") is not None:
-        return int(span["duplicate_rows"])
-    return None
-
-
-def _build_match_index_rows(
-    page_text: str,
-    merged_spans: List[Dict[str, Any]],
-    *,
-    source_path: Path,
-    page_number: int,
-    debug_output_path: Optional[Path] = None,
-) -> List[Dict[str, Any]]:
-    if not merged_spans:
-        return []
-    byte_offsets = _utf8_prefix_byte_offsets(page_text)
-    rows: List[Dict[str, Any]] = []
-    for match_index, span in enumerate(merged_spans, start=1):
-        start = int(span["start"])
-        end = int(span["end"])
-        match_text = page_text[start:end]
-        rows.append(
-            {
-                "match_id": f"{source_path.stem}:page:{page_number}:match:{match_index}",
-                "source_path": str(source_path),
-                "source_stem": source_path.stem,
-                "debug_output_path": None if debug_output_path is None else str(debug_output_path),
-                "page_number": int(page_number),
-                "page_index_in_file": int(page_number),
-                "match_index_in_page": int(match_index),
-                "start_char": start,
-                "end_char": end,
-                "start_byte": int(byte_offsets[start]),
-                "end_byte": int(byte_offsets[end]),
-                "match_length_chars": int(end - start),
-                "match_length_bytes": int(byte_offsets[end] - byte_offsets[start]),
-                "match_types": list(span.get("match_types", [])),
-                "match_type": ",".join(span.get("match_types", [])),
-                "category": str(span.get("category", "")),
-                "kind": span.get("kind"),
-                "repeat_count": _span_repeat_count(span),
-                "period": span.get("period"),
-                "repetitions": span.get("repetitions"),
-                "tail_chars": span.get("tail_chars"),
-                "item_count": span.get("item_count"),
-                "cycle_len": span.get("cycle_len"),
-                "row_count": span.get("row_count"),
-                "duplicate_rows": span.get("duplicate_rows"),
-                "nonempty_ratio": span.get("nonempty_ratio"),
-                "word_count": span.get("word_count"),
-                "char_count": span.get("char_count"),
-                "matched_text": match_text,
-            }
-        )
-    return rows
 
 
 def _build_token_category_page_metric_row(

--- a/src/glossapi/corpus/text_surface_metrics.py
+++ b/src/glossapi/corpus/text_surface_metrics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
+INLINE_DISPLAY_MATH_RE = re.compile(r"(\\\[.*?\\\])|(\\\(.*?\\\))|(\$\$.*?\$\$)", re.S)
+CHAR_COUNT_LATEX_ENV_NAMES = (
+    "equation",
+    "equation*",
+    "align",
+    "align*",
+    "gather",
+    "gather*",
+    "multline",
+    "multline*",
+    "eqnarray",
+    "eqnarray*",
+    "comment",
+)
+
+
+def _strip_latex_envs_for_char_count(text: str) -> str:
+    cleaned = text
+    for env in CHAR_COUNT_LATEX_ENV_NAMES:
+        escaped = re.escape(env)
+        cleaned = re.sub(
+            rf"\\begin\{{{escaped}\}}.*?\\end\{{{escaped}\}}",
+            "",
+            cleaned,
+            flags=re.S,
+        )
+    return cleaned
+
+
+def sanitized_char_count(content: str) -> tuple[int, bool]:
+    """Return export-facing non-whitespace char count and emptiness for text.
+
+    The cleaner, export-facing metadata refresh, and OpenArchives patching must
+    all agree on this contract so they describe the exact published text
+    surface.
+    """
+
+    sanitized = HTML_COMMENT_RE.sub("", content)
+    sanitized = _strip_latex_envs_for_char_count(sanitized)
+    sanitized = INLINE_DISPLAY_MATH_RE.sub("", sanitized)
+    count = sum(1 for ch in sanitized if not ch.isspace())
+    return count, count == 0
+


### PR DESCRIPTION
## Summary

The deferred Stage B from PR #102 — extract OCR span-rendering helpers from `phase_clean.py` into a dedicated `ocr_render.py` module + add `text_surface_metrics.py` for shared published-surface metric helpers. Plus pad `docs/architecture/ocr_cleaning_runtime.md` with the previously-missing sections that describe these modules.

## Why

Per the cleanup-branch architecture (`docs/architecture/ocr_cleaning_runtime.md`): the project benefits from a clean analyzer/renderer separation — `phase_clean.py` decides *what* spans exist; `ocr_render.py` renders *how* those spans become page text. Reduces drift between debug and clean rendering and isolates rendering policy from detector policy.

## Body resolution per "latest changes canonical" rule

Of the 11 functions extracted, 5 had EXACT bodies between dev and faa1362, and 6 had DIFFERENT bodies. The differences exist because dev's Apr 14 OCR-speedup wave modified some functions after faa1362 was authored. **Dev's bodies are used for all 11** (latest = canonical, per memory rule `feedback_cleaner_correctness_axes.md`).

The faa1362-only helper `_build_debug_match_open_tag` is NOT included — dev's `_render_page_from_merged_labeled_spans` (73 lines vs faa1362's 44) inlines the equivalent logic.

## Diff

- New: `src/glossapi/corpus/ocr_render.py` (374 lines)
- New: `src/glossapi/corpus/text_surface_metrics.py` (48 lines)
- Modified: `src/glossapi/corpus/phase_clean.py` (4929 → 4597 lines; +12 import lines, −330 function lines net)
- Modified: `docs/architecture/ocr_cleaning_runtime.md` (118 → 186 lines)

## Verification

- Python syntax check: all 3 .py files parse OK.
- Direct module import: ocr_render + text_surface_metrics import cleanly.
- Pytest: **67 passed, 2 failed** on `tests/test_corpus_clean_enhancements.py`.
- The 2 failures (`test_clean_flags_uppercase_glyph_noise` + `test_clean_token_category_debug_exports_synthetic_pages`) are **pre-existing dev failures** — verified by running the same tests against unmodified `origin/development`. Not introduced by this extraction.
- The Rust cleaner crate is untouched, so the byte-identical output verification from PR #102 still holds.

## After merge

This completes goal 1 (all branch work integrated). The remaining branches to delete:
- `cleanup/cleaner-pipeline-20260425` (subsumed by PR #102 + this PR)
- `codex/ocr-clean-rust-speedup` (faa1362 absorbed via this PR)
- `codex/ocr-env-fix` (no remaining unique work)
- `codex/integration-ocr-vllm-clean-0.1.4-held` (no remaining unique work)
- `origin/codex/ocr-vllm-defaults-refactor` (explicit no-port decision)

End state: only `master` and `development` remain.