### PR TITLE
clean[_ocr]: skip chunk markdown when canonical doc exists; widen OCR word-repeat window default

### DIFF
--- a/src/glossapi/corpus/phase_clean.py
+++ b/src/glossapi/corpus/phase_clean.py
@@ -71,6 +71,11 @@ WORD_REPEAT_HASH_BASE = 1469598103934665603
 # still small enough to read as one corrupted region rather than two separate
 # failures. This is intentionally more permissive than the older 10-char rule.
 WORD_REPEAT_MERGE_MAX_NONWHITESPACE_GAP = 40
+# Default word-repeat detection window for OCR cleaning. Wider than the
+# legacy 96 so accent-shifted Greek repetitions (period > 32 chars) get
+# caught — see test_long_accent_shift_repeat_needs_wider_default_window.
+DEFAULT_OCR_WORD_REPEAT_MAX_PERIOD = 130
+DEFAULT_OCR_WORD_REPEAT_WINDOW = DEFAULT_OCR_WORD_REPEAT_MAX_PERIOD * 4
 EXISTING_MATCH_BLOCK_RE = re.compile(r"(?is)<match\b[^>]*>.*?</match\s*>")
 LATEX_BLOCK_RE = re.compile(r"(?is)\$\$.*?\$\$")
 LATEX_BRACKET_RE = re.compile(r"(?is)\\\[.*?\\\]")
@@ -2986,6 +2991,18 @@ class CleanPhaseMixin:
         report_parquet_path = self.cleaned_markdown_dir.parent / "cleaning_report.parquet"
 
         md_files = sorted(input_dir.glob("*.md"))
+        if md_files:
+            # Skip per-page-range chunk markdown when the canonical merged
+            # doc.md exists alongside doc__pNNNNN-NNNNN.md outputs from the
+            # OCR runner. Cleaning both would double-count the same content.
+            canonical_files = {canonical_stem(path.name): path for path in md_files if "__p" not in path.stem}
+            if canonical_files:
+                filtered_md_files = []
+                for path in md_files:
+                    if "__p" in path.stem and canonical_stem(path.name) in canonical_files:
+                        continue
+                    filtered_md_files.append(path)
+                md_files = filtered_md_files
         total_files = len(md_files)
 
         self.logger.info(
@@ -3481,7 +3498,7 @@ class CleanPhaseMixin:
         min_same_digit_steps: int = 10,
         word_rep_threshold: int = 4,
         word_min_period: int = 3,
-        word_window: int = 96,
+        word_window: int = DEFAULT_OCR_WORD_REPEAT_WINDOW,
     ) -> None:
         """Clean OCR markdown with the shared page loop and update OCR-noise metrics.
 
@@ -3520,6 +3537,18 @@ class CleanPhaseMixin:
             max_workers=n_threads,
         )
         md_files = sorted(input_dir.glob("*.md"))
+        if md_files:
+            # Skip per-page-range chunk markdown when the canonical merged
+            # doc.md exists alongside doc__pNNNNN-NNNNN.md outputs from the
+            # OCR runner. Cleaning both would double-count the same content.
+            canonical_files = {canonical_stem(path.name): path for path in md_files if "__p" not in path.stem}
+            if canonical_files:
+                filtered_md_files = []
+                for path in md_files:
+                    if "__p" in path.stem and canonical_stem(path.name) in canonical_files:
+                        continue
+                    filtered_md_files.append(path)
+                md_files = filtered_md_files
         debug_dir: Optional[Path] = None
         debug_manifest_path: Optional[Path] = None
         debug_page_metrics_path: Optional[Path] = None
@@ -4118,7 +4147,7 @@ class CleanPhaseMixin:
         min_same_digit_steps: int = 10,
         word_rep_threshold: int = 4,
         word_min_period: int = 3,
-        word_window: int = 96,
+        word_window: int = DEFAULT_OCR_WORD_REPEAT_WINDOW,
     ) -> List[Dict[str, Any]]:
         """Annotate complete markdown documents with table, numeric, LaTeX, hybrid, then shared-repeat matches.
 
@@ -4493,7 +4522,7 @@ class CleanPhaseMixin:
         doc_offset: int = 0,
         word_rep_threshold: int = 4,
         word_min_period: int = 3,
-        word_window: int = 96,
+        word_window: int = DEFAULT_OCR_WORD_REPEAT_WINDOW,
     ) -> List[Dict[str, Any]]:
         """Export only matched pages for all LaTeX repeat classes."""
         if input_dir is None:

--- a/tests/test_corpus_clean_enhancements.py
+++ b/tests/test_corpus_clean_enhancements.py
@@ -9,6 +9,7 @@ import pytest
 
 from glossapi import Corpus
 from glossapi.corpus.phase_clean import (
+    DEFAULT_OCR_WORD_REPEAT_WINDOW,
     _find_word_repeat_spans,
     _find_word_repeat_spans_python,
     _merge_labeled_raw_spans,
@@ -326,6 +327,21 @@ def test_clean_ocr_supports_score_only_mode(tmp_path: Path) -> None:
     corpus.clean_ocr(write_cleaned_files=False)
     assert not any(corpus.cleaned_markdown_dir.glob("*.md"))
     assert corpus.markdown_dir == corpus.output_dir / "markdown"
+
+
+def test_clean_ocr_ignores_chunk_markdown_when_canonical_doc_exists(tmp_path: Path) -> None:
+    corpus = _build_corpus(tmp_path)
+    (corpus.markdown_dir / "doc.md").write_text("Κανονικό κείμενο.\n", encoding="utf-8")
+    (corpus.markdown_dir / "doc__p00001-00010.md").write_text("Θορυβώδες chunk.\n", encoding="utf-8")
+
+    corpus.clean_ocr()
+
+    cleaned_files = sorted(path.name for path in corpus.cleaned_markdown_dir.glob("*.md"))
+    assert cleaned_files == ["doc.md"]
+
+    parquet = corpus.output_dir / "download_results" / "download_results.parquet"
+    df = pd.read_parquet(parquet)
+    assert "doc.pdf" in df["filename"].tolist()
 
 
 def test_clean_ocr_supports_combined_clean_and_debug_outputs(tmp_path: Path) -> None:
@@ -842,6 +858,30 @@ def test_rust_word_repeat_spans_match_python_reference(tmp_path: Path) -> None:
             min_period=3,
             window=96,
         )
+
+
+def test_long_accent_shift_repeat_needs_wider_default_window() -> None:
+    line_a = "\"Ελληνική\" ειδήματα, θανεί σει σάφησαν τ' άγχιλίαν"
+    line_b = "\"Ελληνική\" ειδήματα, θανεί σει σάφησαν τ' άγχίλιαν"
+    normalized, _ = _normalize_alnum_with_map_skip_tags("\n".join([line_a, line_b] * 6))
+
+    legacy_spans = _find_word_repeat_spans_python(
+        normalized,
+        rep_threshold=4,
+        min_period=3,
+        window=96,
+    )
+    default_spans = _find_word_repeat_spans_python(
+        normalized,
+        rep_threshold=4,
+        min_period=3,
+        window=DEFAULT_OCR_WORD_REPEAT_WINDOW,
+    )
+
+    assert legacy_spans == []
+    assert default_spans
+    assert default_spans[0]["period"] == 40
+    assert default_spans[0]["repetitions"] >= 6
 
 
 def test_clean_ocr_numeric_word_debug_docs_flags_empty_html_table_collapse(tmp_path: Path) -> None:


### PR DESCRIPTION
Forward-port of 2 Apr 17 uncommitted edits from the deleted ocr-env-fix worktree.

## 1. Skip chunk markdown when canonical doc exists
When the OCR runner emits both `doc.md` and `doc__p00001-00010.md`, the cleaner used to clean BOTH — double-counting. Now both `Corpus.clean()` and `Corpus.clean_ocr()` skip `__p`-suffixed chunks when the canonical doc is present.

## 2. Widen OCR word-repeat window default 96 → 520
Two new constants: `DEFAULT_OCR_WORD_REPEAT_MAX_PERIOD = 130` and `DEFAULT_OCR_WORD_REPEAT_WINDOW = 520`. The legacy 96 missed accent-shifted Greek repetitions (period > 32 chars). Applied to `clean_ocr()`, `clean_ocr_debug()`, `clean_ocr_numeric_debug()`.

## Tests
- `test_clean_ocr_ignores_chunk_markdown_when_canonical_doc_exists` — passes.
- `test_long_accent_shift_repeat_needs_wider_default_window` — proves legacy 96 misses, new 520 catches.
